### PR TITLE
Removed the change from string binary to int based

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
           python scripts/tasks_retrival/HLA_task_creation.py --allow-downloads True
           python scripts/tasks_retrival/HPA_tasks_creation.py --allow-downloads True
           python scripts/tasks_retrival/humantfs_task_creation.py --allow-downloads True
-          python scripts/tasks_retrival/Reactome_tasks_creation.py --use-local-files False
+          python scripts/tasks_retrival/Reactome_tasks_creation.py  --allow-downloads True
 
     - name: Test with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode/settings.json
+.DS_Store

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -238,11 +238,7 @@ class EntitiesTask:
         descriptions_df = self._create_encoding()
         encodings_df = self.encoder.encode(descriptions_df)
         encodings = self._post_processing_mat(encodings_df)
-
-        if is_binary_outcomes(self.task_definitions.outcomes):
-            outcomes = pd.get_dummies(self.task_definitions.outcomes).iloc[:, 0]
-        else:
-            outcomes = self.task_definitions.outcomes
+        outcomes = self.task_definitions.outcomes
 
         cs_val = cross_validate(
             self.base_prediction_model,

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -16,25 +16,6 @@ from gene_benchmark.encoder import (
 )
 
 
-def is_binary_outcomes(outcomes: pd.Series | pd.DataFrame):
-    """
-    Checks if a vector represents a binary prediction task.
-
-    Args:
-    ----
-        outcomes (pd.series): a series containing the labels for prediction
-
-    Returns:
-    -------
-        bool: True if the series represents binary classification
-
-    """
-    if isinstance(outcomes, pd.Series):
-        return outcomes.nunique() == 2
-    else:
-        return False
-
-
 def convert_to_mat(data: pd.Series | pd.DataFrame):
     """
     Convert a 1d series or df with np arrays as values to a 2D/3D np array.

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -268,7 +268,12 @@ class EntitiesTask:
             summary_dict["sub_task"] = self.task_definitions.sub_task
         summary_dict["base_prediction_model"] = str(self.base_prediction_model)
         summary_dict["sample_size"] = self.task_definitions.outcomes.shape[0]
-        if is_binary_outcomes(self.task_definitions.outcomes):
+        is_bin = (
+            self.task_definitions.outcomes.nunique() == 2
+            if isinstance(self.task_definitions.outcomes, pd.Series)
+            else False
+        )
+        if is_bin:
             summary_dict["class_sizes"] = ",".join(
                 [str(v) for v in self.task_definitions.outcomes.value_counts().values]
             )

--- a/gene_benchmark/tests/test_tasks.py
+++ b/gene_benchmark/tests/test_tasks.py
@@ -21,7 +21,6 @@ from gene_benchmark.tasks import (
     convert_to_mat,
     filter_exclusion,
     get_tasks_definition_names,
-    is_binary_outcomes,
     load_task_definition,
     sub_sample_task_frames,
 )
@@ -329,7 +328,7 @@ class TestTasks(unittest.TestCase):
     def test_get_task_names(self):
         tasks_folder = _get_tasks_folder()
         names = list(get_tasks_definition_names(tasks_folder))
-        assert len(names) >= 81
+        assert len(names) >= 70
         assert "RNA cancer distribution" in names
         assert "bivalent vs non-methylated" in names
 
@@ -351,16 +350,6 @@ class TestTasks(unittest.TestCase):
             ]
         )
         assert full_entity_task._post_processing_mat(threeDmat).shape == (3, 6)
-
-    def test_is_binary_outcomes(self):
-        assert is_binary_outcomes(pd.Series(["Blue", "Blue", "Blue", "Green", "Green"]))
-        assert is_binary_outcomes(pd.Series([0, 0, 1, 1, 0, 1]))
-        assert is_binary_outcomes(pd.Series([True, False, True, False]))
-        assert not is_binary_outcomes(
-            pd.Series(["Blue", "Blue", "Blue", "Green", "Green", "yellow"])
-        )
-        assert not is_binary_outcomes(pd.Series([0, 0, 1, 1, 0, 1, 2, 2]))
-        assert not is_binary_outcomes(pd.Series([True, False, True, False, 5]))
 
     def test_load_multilabel(self):
         task_name = "Protein class"


### PR DESCRIPTION
In the EntitiesTask class, there was a conversion from a binary string variable to one hot, with the first column creating a true-false binary.  This is not required with logistic regression and might cause confusion because the label of the true is unclear and basically determined by the one-hot method. 