### PR TITLE
Task on overlapping

### DIFF
--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -256,7 +256,7 @@ class EntitiesTask:
             )
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
-            df = self.task_definitions.outcomes
+            outcomes = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
 
         cs_val = cross_validate(

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -106,7 +106,7 @@ def _convert_df_to_3d_array(df: pd.DataFrame):
         )
     return np.hstack(reshaped_embeddings)
 
-def _get_none_nan_instancies(encodings,outcomes):
+def _get_none_nan_instancies(encodings:pd.DataFrame,outcomes:pd.Series|pd.DataFrame):
     if isinstance(encodings,pd.Series):
         nan_ind = encodings.isna()
     else:
@@ -246,8 +246,12 @@ class EntitiesTask:
         """
         descriptions_df = self._create_encoding()
         encodings_df = self.encoder.encode(descriptions_df)
-        encodings = self._post_processing_mat(encodings_df)
-        outcomes = self.task_definitions.outcomes
+        if self.overlap_genes:
+            outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
+            encodings = self._post_processing_mat(encodings_df.dropna())
+        else:
+            outcomes = self.task_definitions.outcomes
+            encodings = self._post_processing_mat(encodings_df)
 
         cs_val = cross_validate(
             self.base_prediction_model,

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -91,8 +91,8 @@ def _convert_df_to_3d_array(df: pd.DataFrame):
 def _get_none_nan_instancies(
     encodings: pd.DataFrame, outcomes: pd.Series | pd.DataFrame
 ):
-    if isinstance(encodings.squeeze(), pd.Series):
-        nan_ind = encodings.isna()
+    if encodings.shape[1] == 1:
+        nan_ind = encodings.squeeze().isna()
     else:
         nan_ind = encodings.isna().any()
     if isinstance(outcomes, pd.Series):
@@ -150,7 +150,7 @@ class EntitiesTask:
         model_name=None,
         sub_task=None,
         multi_label_th=0,
-        overlap_entities=True,
+        overlap_entities=False,
     ) -> None:
         """
         Initiate a ClassificationGeneTask object.

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -250,7 +250,7 @@ class EntitiesTask:
             outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
-            df = self.task_definitions.outcomes
+            outcomes = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
 
         cs_val = cross_validate(

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -106,6 +106,16 @@ def _convert_df_to_3d_array(df: pd.DataFrame):
         )
     return np.hstack(reshaped_embeddings)
 
+def _get_none_nan_instancies(encodings,outcomes):
+    if isinstance(encodings,pd.Series):
+        nan_ind = encodings.isna()
+    else:
+        nan_ind = encodings.isna().any()
+    if isinstance(encodings,pd.Series):
+        return outcomes[~nan_ind]
+    else: 
+        return outcomes.loc[~nan_ind,:]
+
 
 @dataclass
 class TaskDefinition:
@@ -131,7 +141,6 @@ def concat_list_df(list_df):
     if list_df.shape[1] > 1:
         list_df = list_df.apply(np.concatenate, axis=1)
     return np.stack(list_df)
-
 
 class EntitiesTask:
     """
@@ -222,7 +231,7 @@ class EntitiesTask:
             return encodings_mat
         if self.encoding_post_processing == "concat":
             return concat_list_df(encoding)
-
+        
     def run(self, error_score=np.nan):
         """
         Runs the defined ina k-fold fashion and returns a dictionary with the scores

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -292,7 +292,12 @@ class EntitiesTask:
             summary_dict["sub_task"] = self.task_definitions.sub_task
         summary_dict["base_prediction_model"] = str(self.base_prediction_model)
         summary_dict["sample_size"] = self.task_definitions.outcomes.shape[0]
-        if is_binary_outcomes(self.task_definitions.outcomes):
+        is_bin = (
+            self.task_definitions.outcomes.nunique() == 2
+            if isinstance(self.task_definitions.outcomes, pd.Series)
+            else False
+        )
+        if is_bin:
             summary_dict["class_sizes"] = ",".join(
                 [str(v) for v in self.task_definitions.outcomes.value_counts().values]
             )

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -236,6 +236,19 @@ class EntitiesTask:
         if self.encoding_post_processing == "concat":
             return concat_list_df(encoding)
 
+    def _prepare_datamat_and_labels(self):
+        descriptions_df = self._create_encoding()
+        encodings_df = self.encoder.encode(descriptions_df)
+        if self.overlap_genes:
+            outcomes = _get_none_nan_instancies(
+                encodings_df, self.task_definitions.outcomes
+            )
+            encodings = self._post_processing_mat(encodings_df.dropna())
+        else:
+            outcomes = self.task_definitions.outcomes
+            encodings = self._post_processing_mat(encodings_df)
+        return outcomes, encodings
+
     def run(self, error_score=np.nan):
         """
         Runs the defined ina k-fold fashion and returns a dictionary with the scores
@@ -248,17 +261,7 @@ class EntitiesTask:
             dict: a dictionary containing the score results and metadata on the run.
 
         """
-        descriptions_df = self._create_encoding()
-        encodings_df = self.encoder.encode(descriptions_df)
-        if self.overlap_genes:
-            outcomes = _get_none_nan_instancies(
-                encodings_df, self.task_definitions.outcomes
-            )
-            encodings = self._post_processing_mat(encodings_df.dropna())
-        else:
-            outcomes = self.task_definitions.outcomes
-            encodings = self._post_processing_mat(encodings_df)
-
+        outcomes, encodings = self._prepare_datamat_and_labels()
         cs_val = cross_validate(
             self.base_prediction_model,
             encodings,

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -222,6 +222,7 @@ class EntitiesTask:
     def _prepare_datamat_and_labels(self):
         descriptions_df = self._create_encoding()
         encodings_df = self.encoder.encode(descriptions_df)
+
         if self.overlap_entities:
             outcomes = _get_none_nan_instancies(
                 encodings_df, self.task_definitions.outcomes
@@ -230,6 +231,7 @@ class EntitiesTask:
         else:
             outcomes = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
+        self.overlapped_task_size = len(outcomes)
         return outcomes, encodings
 
     def run(self, error_score=np.nan):
@@ -287,6 +289,11 @@ class EntitiesTask:
                     str(v)
                     for v in self.task_definitions.outcomes.value_counts().index.values
                 ]
+            )
+        if self.overlap_entities:
+            summary_dict["overlapped_task_size"] = self.overlapped_task_size
+            summary_dict["original_task_size"] = len(
+                self.task_definitions.outcomes.value_counts()
             )
         if self.description_builder:
             summary_dict.update(self.description_builder.summary())

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -250,6 +250,7 @@ class EntitiesTask:
             outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
+            
             outcomes = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
 

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -270,6 +270,8 @@ class EntitiesTask:
         if self.overlap_entities:
             summary_dict["overlapped_sample_size"] = len(self.nan_ind)
             outcomes = self.task_definitions.outcomes.loc[self.nan_ind]
+        else:
+            outcomes = self.task_definitions.outcomes
         if is_bin:
             summary_dict["class_sizes"] = ",".join(
                 [str(v) for v in outcomes.value_counts().values]

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -106,15 +106,18 @@ def _convert_df_to_3d_array(df: pd.DataFrame):
         )
     return np.hstack(reshaped_embeddings)
 
-def _get_none_nan_instancies(encodings:pd.DataFrame,outcomes:pd.Series|pd.DataFrame):
-    if isinstance(encodings,pd.Series):
+
+def _get_none_nan_instancies(
+    encodings: pd.DataFrame, outcomes: pd.Series | pd.DataFrame
+):
+    if isinstance(encodings, pd.Series):
         nan_ind = encodings.isna()
     else:
         nan_ind = encodings.isna().any()
-    if isinstance(encodings,pd.Series):
+    if isinstance(encodings, pd.Series):
         return outcomes[~nan_ind]
-    else: 
-        return outcomes.loc[~nan_ind,:]
+    else:
+        return outcomes.loc[~nan_ind, :]
 
 
 @dataclass
@@ -141,6 +144,7 @@ def concat_list_df(list_df):
     if list_df.shape[1] > 1:
         list_df = list_df.apply(np.concatenate, axis=1)
     return np.stack(list_df)
+
 
 class EntitiesTask:
     """
@@ -231,7 +235,7 @@ class EntitiesTask:
             return encodings_mat
         if self.encoding_post_processing == "concat":
             return concat_list_df(encoding)
-        
+
     def run(self, error_score=np.nan):
         """
         Runs the defined ina k-fold fashion and returns a dictionary with the scores
@@ -247,7 +251,9 @@ class EntitiesTask:
         descriptions_df = self._create_encoding()
         encodings_df = self.encoder.encode(descriptions_df)
         if self.overlap_genes:
-            outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
+            outcomes = _get_none_nan_instancies(
+                encodings_df, self.task_definitions.outcomes
+            )
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
             df = self.task_definitions.outcomes

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -114,7 +114,7 @@ def _get_none_nan_instancies(
         nan_ind = encodings.isna()
     else:
         nan_ind = encodings.isna().any()
-    if isinstance(encodings, pd.Series):
+    if isinstance(outcomes, pd.Series):
         return outcomes[~nan_ind]
     else:
         return outcomes.loc[~nan_ind, :]

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -91,7 +91,7 @@ def _convert_df_to_3d_array(df: pd.DataFrame):
 def _get_none_nan_instancies(
     encodings: pd.DataFrame, outcomes: pd.Series | pd.DataFrame
 ):
-    if isinstance(encodings, pd.Series):
+    if isinstance(encodings.squeeze(), pd.Series):
         nan_ind = encodings.isna()
     else:
         nan_ind = encodings.isna().any()

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -169,6 +169,7 @@ class EntitiesTask:
         model_name=None,
         sub_task=None,
         multi_label_th=0,
+        overlap_entities=True,
     ) -> None:
         """
         Initiate a ClassificationGeneTask object.
@@ -217,6 +218,7 @@ class EntitiesTask:
         self.return_estimator = return_estimator
         self.encoding_post_processing = encoding_post_processing
         self.model_name = model_name
+        self.overlap_entities = overlap_entities
 
     def _create_encoding(self):
         if self.description_builder is None:
@@ -239,7 +241,7 @@ class EntitiesTask:
     def _prepare_datamat_and_labels(self):
         descriptions_df = self._create_encoding()
         encodings_df = self.encoder.encode(descriptions_df)
-        if self.overlap_genes:
+        if self.overlap_entities:
             outcomes = _get_none_nan_instancies(
                 encodings_df, self.task_definitions.outcomes
             )

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -250,7 +250,7 @@ class EntitiesTask:
             outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
-            outcomes = self.task_definitions.outcomes
+            df = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
 
         cs_val = cross_validate(

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -250,8 +250,7 @@ class EntitiesTask:
             outcomes = _get_none_nan_instancies(encodings_df,self.task_definitions.outcomes)
             encodings = self._post_processing_mat(encodings_df.dropna())
         else:
-            
-            outcomes = self.task_definitions.outcomes
+            df = self.task_definitions.outcomes
             encodings = self._post_processing_mat(encodings_df)
 
         cs_val = cross_validate(

--- a/gene_benchmark/tests/test_tasks.py
+++ b/gene_benchmark/tests/test_tasks.py
@@ -169,6 +169,20 @@ class TestTasks(unittest.TestCase):
         full_entity_task.run()
         assert not full_entity_task._cv_report is None
 
+    def test_entities_task_overlap(self):
+        task_name = "long vs short range TF"
+        mpnet_name = "sentence-transformers/all-mpnet-base-v2"
+        full_entity_task = EntitiesTask(
+            task=task_name,
+            tasks_folder=_get_tasks_folder(),
+            encoder=mpnet_name,
+            description_builder=NCBIDescriptor(),
+            base_model=LogisticRegression(max_iter=2000, multi_class="auto"),
+            overlap_entities=True,
+        )
+        full_entity_task.run()
+        assert not full_entity_task._cv_report is None
+
     def test_multiclass_task_mini(self):
         task_name = "test_multiclass"
         mpnet_name = "sentence-transformers/all-mpnet-base-v2"


### PR DESCRIPTION
The entities task class is a pipeline class that enables the performance of a prediction task using a specific model.
Currently, the user can exclude certain entities from the task. Thus, the user could check the overlapping symbols of a task and a model and exclude the nonoverlapping. 

However, in some use cases, the user will want to compare several models on several tasks, so the user must manage an exclusion list per model. This change will enable the running of multiple models on the same task while creating an exclusion per model.
The following change will add this option to the run task script, allowing the user to use the workflow in one line. 

Currently, the code removes rows after encoding; for encodings that have a list of the covered symbols (such as pre-computed), we could have loaded the task with the covered genes only, yet for text encoders, we do not have the covered symbols for the more generic, yet maybe less effective solution was selected.

I'm uncertain about the summary. I left most of it on the original task, yet maybe we would like to report the task only on the overlap; what do you think?
