### PR TITLE
Add dummy conversion to binary outcomes

### DIFF
--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -17,7 +17,7 @@ from gene_benchmark.encoder import (
 )
 
 
-def is_binary_outcomes(outcomes: pd.Series | pd.DataFrame):
+def is_binary_outcomes(outcomes: pd.Series | pd.DataFrame) -> bool:
     """
     Checks if a vector represents a binary prediction task.
 

--- a/gene_benchmark/tasks.py
+++ b/gene_benchmark/tasks.py
@@ -270,7 +270,8 @@ class EntitiesTask:
 
     def run(self, error_score=np.nan):
         """
-        Runs the defined ina k-fold fashion and returns a dictionary with the scores
+        Runs the defined ina k-fold fashion and returns a dictionary with the scores.
+        In the case of a binary outcome, the outcomes will be converted to dummy, in alphabetical order.
         error_score: exposing a cross_validate option - on error in computation:
             return np.nan (default) or error_score="raise" to raise an exception.
             Useful for debugging.  Default follows default of cross_validate function.


### PR DESCRIPTION
Convert the binary outcomes to dummy (0/1). This is needed when computing the f1 score. It expects a numerical outcome. 